### PR TITLE
Update asset precompilation to only include non-partial SCSS files

### DIFF
--- a/lib/themes_on_rails/engine.rb
+++ b/lib/themes_on_rails/engine.rb
@@ -30,7 +30,7 @@ module ThemesOnRails
         relative_entry = Pathname.new(entry).relative_path_from(themes_root).to_s
         base_name = File.basename(relative_entry)
 
-        if !base_name.starts_with?('_') || !%w(.js .css).include?(File.extname(entry)) || relative_entry =~ allowed_assets_regex
+        if !base_name.starts_with?('_') || !%w(.js .css .scss).include?(File.extname(entry)) || relative_entry =~ allowed_assets_regex
           app.config.assets.precompile << entry
         end
       end

--- a/lib/themes_on_rails/engine.rb
+++ b/lib/themes_on_rails/engine.rb
@@ -28,7 +28,9 @@ module ThemesOnRails
         # 2. allow start_with all_ or all-
         # 3. allow all.js and all.css
         relative_entry = Pathname.new(entry).relative_path_from(themes_root).to_s
-        if !%w(.js .css).include?(File.extname(entry)) || relative_entry =~ allowed_assets_regex
+        base_name = File.basename(relative_entry)
+
+        if !base_name.starts_with?('_') || !%w(.js .css).include?(File.extname(entry)) || relative_entry =~ allowed_assets_regex
           app.config.assets.precompile << entry
         end
       end


### PR DESCRIPTION
Partial SCSS files starting with an underscore (_) should not be added to the precompilation array.