### PR TITLE
Use pre-compiled file system resolvers instead of strings as argument…

### DIFF
--- a/lib/themes_on_rails/action_controller.rb
+++ b/lib/themes_on_rails/action_controller.rb
@@ -28,24 +28,28 @@ module ThemesOnRails
 
         controller_class.send(filter_method, options) do |controller|
 
-          # prepend view path
-          controller.prepend_view_path theme_instance.theme_view_path
+          # #prepend_view_path leaks memory when called with a String argument, see https://www.spacevatican.org/2019/5/4/debugging-a-memory-leak-in-a-rails-app/. To alleviate this, we check if there are precompiled resolvers available and use them instead. String path prepending is only used as a last resort.
+          if defined?(THEMES_ON_RAILS_RESOLVERS) && THEMES_ON_RAILS_RESOLVERS.is_a?(Hash)
+            controller.prepend_view_path THEMES_ON_RAILS_RESOLVERS.fetch(theme_instance.theme_name, theme_instance.theme_name)
+          else
+            controller.prepend_view_path theme_instance.theme_view_path
+          end
 
           # liquid file system
           Liquid::Template.file_system = Liquid::Rails::FileSystem.new(theme_instance.theme_view_path) if defined?(Liquid::Rails)
         end
       end
 
-      private
+    private
 
-        def before_filter_method(options)
-          case Rails::VERSION::MAJOR
-          when 3
-            options.delete(:prepend) ? :prepend_before_filter : :before_filter
-          when 4, 5
-            options.delete(:prepend) ? :prepend_before_action : :before_action
-          end
+      def before_filter_method(options)
+        case Rails::VERSION::MAJOR
+        when 3
+          options.delete(:prepend) ? :prepend_before_filter : :before_filter
+        when 4, 5
+          options.delete(:prepend) ? :prepend_before_action : :before_action
         end
+      end
     end
 
     def initialize(controller, theme)


### PR DESCRIPTION
Providing a String argument to `prepend_view_path` results in a memory leak, see https://www.spacevatican.org/2019/5/4/debugging-a-memory-leak-in-a-rails-app/ for details. By pre-compiling and caching instances of `ActionView::OptimizedFileSystemResolver` for each theme, we can pass these resolvers to `prepend_view_path` and thus fix the leak.